### PR TITLE
Add Redmine 3.2.x support

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,6 @@ if Gem::Version.new("3.0") > Gem::Version.new(Rails.version) then
   end
 else
   RedmineApp::Application.routes.draw do
-    match 'projects/:id/wiki/decode', :to => 'redmine_wikicipher', :action => 'decode'
+    get 'projects/:id/wiki/decode', :to => 'redmine_wikicipher', :action => 'decode'
   end
 end

--- a/lib/redmine_wikicipher/hooks.rb
+++ b/lib/redmine_wikicipher/hooks.rb
@@ -33,10 +33,10 @@ module RedmineWikicipher
 		current = current.title
 
 		if context[:toggle]=='1'
-			link = "<a href=\"/projects/"+context[:id]+"/wiki/"+current+"?version="+context[:version].to_s+"&decode="+context[:toggle]+"\" class=\"icon icon-decrypt\"><%= t 'redmine_wikicipher.decode' %></a>"
+			link = "<a href=\""+projects_path+"/"+context[:id]+"/wiki/"+current+"?version="+context[:version].to_s+"&decode="+context[:toggle]+"\" class=\"icon icon-decrypt\"><%= t 'redmine_wikicipher.decode' %></a>"
 			link = link.force_encoding("UTF-8")
 		else
-			link = "<a href=\"/projects/"+context[:id]+"/wiki/"+current+"?version="+context[:version].to_s+"&decode="+context[:toggle]+"\" class=\"icon icon-encrypt\"><%= t 'redmine_wikicipher.encode' %></a>"
+			link = "<a href=\""+projects_path+"/"+context[:id]+"/wiki/"+current+"?version="+context[:version].to_s+"&decode="+context[:toggle]+"\" class=\"icon icon-encrypt\"><%= t 'redmine_wikicipher.encode' %></a>"
 			link = link.force_encoding("UTF-8")
 		end	
 		hideLink=1

--- a/lib/wiki_controller_patch.rb
+++ b/lib/wiki_controller_patch.rb
@@ -171,11 +171,11 @@ module WikiControllerPatch
     if User.current.allowed_to?(:export_wiki_pages, @project)
       if params[:format] == 'pdf'
 	params[:decode]='1'
-         @content.text = decodeContent(@content.text,params,0,1);
-	 
-	 clone = @page.clone
-	clone.content = @content
-        send_data(wiki_page_to_pdf(clone, @project), :type => 'application/pdf', :filename => "#{clone.title}.pdf")
+        @content.text = decodeContent(@content.text,params,0,1);
+        @page = @page.dup
+	@page.content = @content
+        #send_data(wiki_page_to_pdf(clone, @project), :type => 'application/pdf', :filename => "#{clone.title}.pdf")
+        send_file_headers! :type => 'application/pdf', :filename => "#{@page.title}.pdf"
         return
       elsif params[:format] == 'html'
 	params[:decode]='1'

--- a/lib/wiki_controller_patch.rb
+++ b/lib/wiki_controller_patch.rb
@@ -42,7 +42,7 @@ module WikiControllerPatch
 	def decrypt(encodedContent)
 		e = OpenSSL::Cipher::Cipher.new 'DES-EDE3-CBC'
 		e.decrypt $key
-		s = encodedContent.to_a.pack("H*").unpack("C*").pack("c*")
+		s = Array(encodedContent).pack("H*").unpack("C*").pack("c*")
 		s = e.update s
 		decoded = s << e.final
 		return decoded


### PR DESCRIPTION
This PR adds support for Redmine 3.2.x and Rails 4 to the Redmine Wikicipher plugin.

Fixes #26.
